### PR TITLE
add init.sh file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ ADD setup/install.sh /root/install.sh
 # add packer bash script
 ADD setup/packer.sh /root/packer.sh
 
+# add packer bash script
+ADD setup/init.sh /root/init.sh
+
 # add custom environment file for application
 ADD setup/setup.sh /home/nobody/setup.sh
 


### PR DESCRIPTION
This fixes the error in the latest build.

“/bin/bash: /root/init.sh: No such file or directory”
